### PR TITLE
Make Magento from-scratch install work...

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="ShoppingFeed_Manager" setup_version="0.7.0"/>
+    <module name="ShoppingFeed_Manager" setup_version="0.7.0">
+        <sequence>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Payment"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
...by adding missing dependencies thus fixing the installation order and avoid queries on non-existing tables yet.

Please note that these are minimal requirements, probably not reflecting the actual module's dependencies.