### PR TITLE
Fix issue when calling checkQuoteItemQty function

### DIFF
--- a/Plugin/CatalogInventory/Spi/StockStateProviderPlugin.php
+++ b/Plugin/CatalogInventory/Spi/StockStateProviderPlugin.php
@@ -66,7 +66,7 @@ class StockStateProviderPlugin
         StockItemInterface $stockItem,
         $itemQty,
         $qtyToCheck,
-        $origQty
+        $origQty = 0
     ) {
         return $this->shouldPreventQtyCheck()
             ? $this->dataObjectFactory->create()


### PR DESCRIPTION
Fix issue when calling checkQuoteItemQty method without passing $origQty param, aroundCheckQuoteItemQty method should be set a default value for $origQty same as Magento core.
Reference:
https://github.com/magento/magento2/blob/2.4/app/code/Magento/CatalogInventory/Model/Spi/StockStateProviderInterface.php#L44
https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Model/Spi/StockStateProviderInterface.php#L44
https://github.com/magento/magento2/blob/2.2/app/code/Magento/CatalogInventory/Model/Spi/StockStateProviderInterface.php#L34