### PR TITLE
Add nameInLayout to prevent PHP 8 error

### DIFF
--- a/Block/Adminhtml/Shipping/Method/Rule/Edit/ConditionsForm.php
+++ b/Block/Adminhtml/Shipping/Method/Rule/Edit/ConditionsForm.php
@@ -69,6 +69,7 @@ class ConditionsForm extends GenericForm
         $this->fieldsetRenderer->setTemplate('Magento_CatalogRule::promo/fieldset.phtml');
         $this->fieldsetRenderer->setData('field_set_id', self::FIELDSET_ID);
         $this->fieldsetRenderer->setData('new_child_url', $newConditionUrl);
+        $this->fieldsetRenderer->setNameInLayout('sfm.shipping_method_rules.conditions');
 
         $conditionsFieldset = $form->addFieldset(
             self::FIELDSET_ID,


### PR DESCRIPTION
When going to Sales > Shopping Feed > Shipping Method Rules and selecting one, there is an error message :

```
Deprecated Functionality: stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated in vendor/magento/module-price-permissions/Observer/AdminhtmlBlockHtmlBeforeObserver.php on line 125
Exception in vendor/magento/framework/App/ErrorHandler.php:61
```
